### PR TITLE
Temporary workaround for node compile issue for node-sass

### DIFF
--- a/jitsi-meet/Dockerfile
+++ b/jitsi-meet/Dockerfile
@@ -21,6 +21,7 @@ ENV ENABLE_SMTP=FALSE \
     curl -sSL https://codeload.github.com/jitsi/jitsi-meet/tar.gz/jitsi-meet_$JITSIMEET_VERSION | tar xvfz - --strip 1 -C /app/ ; \
     cd /app ; \
 ### Install
+    rm -rf node_modules package-lock.json ; \
     npm install node-sass@latest ; \
     npm install ; \
     make ; \


### PR DESCRIPTION
What does this commit/PR do?

- Temporarily worksaround the node-sass compile issue below:

`no such file or directory, open '/app/node_modules/.staging`

Why is this commit/PR needed?

- Without node-sass, css is not compiled.